### PR TITLE
Combine processed images using companion OME-XML

### DIFF
--- a/experimentA/companions/Exp1_rep1_0min.companion.ome
+++ b/experimentA/companions/Exp1_rep1_0min.companion.ome
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2016-06"
+	xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06
+	http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd">
+	<Image ID="Image:0" Name="3D images">
+		<Pixels DimensionOrder="XYZTC" ID="Pixels:0:0" Type="uint16" SizeC="5" SizeT="1" SizeX="2048" SizeY="2048" SizeZ="25">
+            <Channel Color="65535" ID="Channel:0:0" Name="Nuclei"/>
+            <Channel Color="-16776961" ID="Channel:0:1" Name="CTT1 filter"/>
+            <Channel Color="-16776961" ID="Channel:0:2" Name="CTT1 immax"/>
+            <Channel Color="16711935" ID="Channel:0:3" Name="STL1 filter"/>
+            <Channel Color="16711935"  ID="Channel:0:4" Name="STL1 immax"/>
+			<TiffData FirstC="0" IFD="0">
+				<UUID FileName="/uod/idr/filesets/idr0047-neuert/20180911-ftp/Exp1_rep1/#2_Analyzed_images/M_nuclei_Exp1_rep1_0min_im1_nuclei3D.tiff">
+					urn:uuid:f2307570-bede-47a7-aa2b-4e23231ac291</UUID>
+			</TiffData>
+			<TiffData FirstC="1" IFD="0">
+				<UUID FileName="/uod/idr/filesets/idr0047-neuert/20180911-ftp/Exp1_rep1/#2_Analyzed_images/SD_mRNA_Exp1_rep1_0min_im1_CY53Dfilter.tiff"
+					>urn:uuid:f2307570-bede-47a7-aa2b-4e23231ac292</UUID>
+			</TiffData>
+			<TiffData FirstC="2" IFD="0">
+				<UUID FileName="/uod/idr/filesets/idr0047-neuert/20180911-ftp/Exp1_rep1/#2_Analyzed_images/SD_mRNA_Exp1_rep1_0min_im1_CY53D3immax.tiff"
+					>urn:uuid:f2307570-bede-47a7-aa2b-4e23231ac293</UUID>
+			</TiffData>
+			<TiffData FirstC="3" IFD="0">
+				<UUID FileName="/uod/idr/filesets/idr0047-neuert/20180911-ftp/Exp1_rep1/#2_Analyzed_images/SD_mRNA_Exp1_rep1_0min_im1_TMR3Dfilter.tiff"
+					>urn:uuid:f2307570-bede-47a7-aa2b-4e23231ac294</UUID>
+			</TiffData>
+			<TiffData FirstC="4" IFD="0">
+				<UUID FileName="/uod/idr/filesets/idr0047-neuert/20180911-ftp/Exp1_rep1/#2_Analyzed_images/SD_mRNA_Exp1_rep1_0min_im1_TMR3D3immax.tiff"
+					>urn:uuid:f2a07570-bede-47a7-aa2b-4e23231ac295</UUID>
+			</TiffData>
+		</Pixels>
+	</Image>
+	<Image ID="Image:1" Name="Projections images">
+		<Pixels DimensionOrder="XYZTC" ID="Pixels:1:0" Type="uint16" SizeC="7" SizeT="1" SizeX="2048" SizeY="2048" SizeZ="1">
+            <Channel Color="-1" ID="Channel:0:0" Name="Cells"/>
+            <Channel Color="-1" ID="Channel:0:1" Name="Brightfield processed"/>
+            <Channel Color="65535" ID="Channel:0:2" Name="Nuclei"/>
+            <Channel Color="-16776961" ID="Channel:0:3" Name="CTT1 max"/>
+            <Channel Color="-16776961" ID="Channel:0:4" Name="CTT1 max filtered"/>
+            <Channel Color="16711935" ID="Channel:0:5" Name="STL1 max"/>
+            <Channel Color="16711935" ID="Channel:0:6" Name="STL1 max filtered"/>
+			<TiffData FirstC="0" IFD="0">
+				<UUID FileName="/uod/idr/filesets/idr0047-neuert/20180911-ftp/Exp1_rep1/#2_Analyzed_images/M_Lab_Exp1_rep1_0min_im1_Cells.tif">
+					urn:uuid:4978087c-a670-4b12-af53-256c62d8d101</UUID>
+			</TiffData>
+			<TiffData FirstC="1" IFD="0">
+				<UUID FileName="/uod/idr/filesets/idr0047-neuert/20180911-ftp/Exp1_rep1/#2_Analyzed_images/M_Lab_Exp1_rep1_0min_im1_trans_plane.tif"
+					>urn:uuid:4978087c-a670-4b12-af53-256c62d8d102</UUID>
+			</TiffData>
+			<TiffData FirstC="2" IFD="0">
+				<UUID FileName="/uod/idr/filesets/idr0047-neuert/20180911-ftp/Exp1_rep1/#2_Analyzed_images/M_nuclei_Exp1_rep1_0min_im1_nuclei.tif"
+					>urn:uuid:4978087c-a670-4b12-af53-256c62d8d103</UUID>
+			</TiffData>
+			<TiffData FirstC="3" IFD="0">
+				<UUID FileName="/uod/idr/filesets/idr0047-neuert/20180911-ftp/Exp1_rep1/#2_Analyzed_images/SD_mRNA_Exp1_rep1_0min_im1_CY5max.tif"
+					>urn:uuid:4978087c-a670-4b12-af53-256c62d8d104</UUID>
+			</TiffData>
+			<TiffData FirstC="4" IFD="0">
+				<UUID FileName="/uod/idr/filesets/idr0047-neuert/20180911-ftp/Exp1_rep1/#2_Analyzed_images/SD_mRNA_Exp1_rep1_0min_im1_CY5maxF.tif"
+					>urn:uuid:4978087c-a670-4b12-af53-256c62d8d105</UUID>
+			</TiffData>
+			<TiffData FirstC="5" IFD="0">
+				<UUID FileName="/uod/idr/filesets/idr0047-neuert/20180911-ftp/Exp1_rep1/#2_Analyzed_images/SD_mRNA_Exp1_rep1_0min_im1_TMRmax.tif"
+					>urn:uuid:4978087c-a670-4b12-af53-256c62d8d106</UUID>
+			</TiffData>
+			<TiffData FirstC="6" IFD="0">
+				<UUID FileName="/uod/idr/filesets/idr0047-neuert/20180911-ftp/Exp1_rep1/#2_Analyzed_images/SD_mRNA_Exp1_rep1_0min_im1_TMRmaxF.tif"
+					>urn:uuid:4978087c-a670-4b12-af53-256c62d8d107</UUID>
+			</TiffData>
+		</Pixels>
+	</Image>
+</OME>

--- a/experimentA/companions/Exp1_rep1_0min.companion.ome
+++ b/experimentA/companions/Exp1_rep1_0min.companion.ome
@@ -12,23 +12,23 @@
             <Channel Color="16711935" ID="Channel:0:3" Name="STL1 filter"/>
             <Channel Color="16711935"  ID="Channel:0:4" Name="STL1 immax"/>
 			<TiffData FirstC="0" IFD="0">
-				<UUID FileName="/uod/idr/filesets/idr0047-neuert/20180911-ftp/Exp1_rep1/#2_Analyzed_images/M_nuclei_Exp1_rep1_0min_im1_nuclei3D.tiff">
+				<UUID FileName="M_nuclei_Exp1_rep1_0min_im1_nuclei3D.tiff">
 					urn:uuid:f2307570-bede-47a7-aa2b-4e23231ac291</UUID>
 			</TiffData>
 			<TiffData FirstC="1" IFD="0">
-				<UUID FileName="/uod/idr/filesets/idr0047-neuert/20180911-ftp/Exp1_rep1/#2_Analyzed_images/SD_mRNA_Exp1_rep1_0min_im1_CY53Dfilter.tiff"
+				<UUID FileName="SD_mRNA_Exp1_rep1_0min_im1_CY53Dfilter.tiff"
 					>urn:uuid:f2307570-bede-47a7-aa2b-4e23231ac292</UUID>
 			</TiffData>
 			<TiffData FirstC="2" IFD="0">
-				<UUID FileName="/uod/idr/filesets/idr0047-neuert/20180911-ftp/Exp1_rep1/#2_Analyzed_images/SD_mRNA_Exp1_rep1_0min_im1_CY53D3immax.tiff"
+				<UUID FileName="SD_mRNA_Exp1_rep1_0min_im1_CY53D3immax.tiff"
 					>urn:uuid:f2307570-bede-47a7-aa2b-4e23231ac293</UUID>
 			</TiffData>
 			<TiffData FirstC="3" IFD="0">
-				<UUID FileName="/uod/idr/filesets/idr0047-neuert/20180911-ftp/Exp1_rep1/#2_Analyzed_images/SD_mRNA_Exp1_rep1_0min_im1_TMR3Dfilter.tiff"
+				<UUID FileName="SD_mRNA_Exp1_rep1_0min_im1_TMR3Dfilter.tiff"
 					>urn:uuid:f2307570-bede-47a7-aa2b-4e23231ac294</UUID>
 			</TiffData>
 			<TiffData FirstC="4" IFD="0">
-				<UUID FileName="/uod/idr/filesets/idr0047-neuert/20180911-ftp/Exp1_rep1/#2_Analyzed_images/SD_mRNA_Exp1_rep1_0min_im1_TMR3D3immax.tiff"
+				<UUID FileName="SD_mRNA_Exp1_rep1_0min_im1_TMR3D3immax.tiff"
 					>urn:uuid:f2a07570-bede-47a7-aa2b-4e23231ac295</UUID>
 			</TiffData>
 		</Pixels>
@@ -43,31 +43,31 @@
             <Channel Color="16711935" ID="Channel:0:5" Name="STL1 max"/>
             <Channel Color="16711935" ID="Channel:0:6" Name="STL1 max filtered"/>
 			<TiffData FirstC="0" IFD="0">
-				<UUID FileName="/uod/idr/filesets/idr0047-neuert/20180911-ftp/Exp1_rep1/#2_Analyzed_images/M_Lab_Exp1_rep1_0min_im1_Cells.tif">
+				<UUID FileName="M_Lab_Exp1_rep1_0min_im1_Cells.tif">
 					urn:uuid:4978087c-a670-4b12-af53-256c62d8d101</UUID>
 			</TiffData>
 			<TiffData FirstC="1" IFD="0">
-				<UUID FileName="/uod/idr/filesets/idr0047-neuert/20180911-ftp/Exp1_rep1/#2_Analyzed_images/M_Lab_Exp1_rep1_0min_im1_trans_plane.tif"
+				<UUID FileName="M_Lab_Exp1_rep1_0min_im1_trans_plane.tif"
 					>urn:uuid:4978087c-a670-4b12-af53-256c62d8d102</UUID>
 			</TiffData>
 			<TiffData FirstC="2" IFD="0">
-				<UUID FileName="/uod/idr/filesets/idr0047-neuert/20180911-ftp/Exp1_rep1/#2_Analyzed_images/M_nuclei_Exp1_rep1_0min_im1_nuclei.tif"
+				<UUID FileName="M_nuclei_Exp1_rep1_0min_im1_nuclei.tif"
 					>urn:uuid:4978087c-a670-4b12-af53-256c62d8d103</UUID>
 			</TiffData>
 			<TiffData FirstC="3" IFD="0">
-				<UUID FileName="/uod/idr/filesets/idr0047-neuert/20180911-ftp/Exp1_rep1/#2_Analyzed_images/SD_mRNA_Exp1_rep1_0min_im1_CY5max.tif"
+				<UUID FileName="SD_mRNA_Exp1_rep1_0min_im1_CY5max.tif"
 					>urn:uuid:4978087c-a670-4b12-af53-256c62d8d104</UUID>
 			</TiffData>
 			<TiffData FirstC="4" IFD="0">
-				<UUID FileName="/uod/idr/filesets/idr0047-neuert/20180911-ftp/Exp1_rep1/#2_Analyzed_images/SD_mRNA_Exp1_rep1_0min_im1_CY5maxF.tif"
+				<UUID FileName="SD_mRNA_Exp1_rep1_0min_im1_CY5maxF.tif"
 					>urn:uuid:4978087c-a670-4b12-af53-256c62d8d105</UUID>
 			</TiffData>
 			<TiffData FirstC="5" IFD="0">
-				<UUID FileName="/uod/idr/filesets/idr0047-neuert/20180911-ftp/Exp1_rep1/#2_Analyzed_images/SD_mRNA_Exp1_rep1_0min_im1_TMRmax.tif"
+				<UUID FileName="SD_mRNA_Exp1_rep1_0min_im1_TMRmax.tif"
 					>urn:uuid:4978087c-a670-4b12-af53-256c62d8d106</UUID>
 			</TiffData>
 			<TiffData FirstC="6" IFD="0">
-				<UUID FileName="/uod/idr/filesets/idr0047-neuert/20180911-ftp/Exp1_rep1/#2_Analyzed_images/SD_mRNA_Exp1_rep1_0min_im1_TMRmaxF.tif"
+				<UUID FileName="SD_mRNA_Exp1_rep1_0min_im1_TMRmaxF.tif"
 					>urn:uuid:4978087c-a670-4b12-af53-256c62d8d107</UUID>
 			</TiffData>
 		</Pixels>

--- a/scripts/check_submission.py
+++ b/scripts/check_submission.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# Generate companion files
+
+
+import glob
+import os
+
+BASE_DIRECTORY = os.environ.get(
+    "BASE_DIRECTORY", "/uod/idr/filesets/idr0047-neuert/20180911-ftp")
+RAW_IMAGES_DIR = "#1_Raw_Images"
+ANALYZED_IMAGES_DIR = "#2_Analyzed_images"
+
+# Based on Table 2: Experimental data sets and conditions
+EXPERIMENTS = {
+    'Exp1_rep1': [0, 1, 2, 4, 6, 8, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55],
+    'Exp1_rep2': [0, 1, 2, 4, 6, 8, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55],
+    'Exp2_rep1': [0, 1, 2, 4, 6, 8, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55],
+    'Exp2_rep2': [0, 1, 2, 4, 6, 8, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55],
+    'Exp2_rep3': [0, 2, 4, 6, 8, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55]
+    }
+POSITIONS = ['im1', 'im2', 'im3', 'im4']
+
+# Review raw images
+raw_images_list = map(
+    os.path.basename,
+    glob.glob("%s/*/%s/*" % (BASE_DIRECTORY, RAW_IMAGES_DIR)))
+expected_images_list = [
+    '%s_%gmin_%s.tif' % (x, y, z) for x in EXPERIMENTS for
+    y in EXPERIMENTS[x] for z in POSITIONS]
+print "Missing raw images: %s" % ",\n".join(
+    sorted(set(expected_images_list) - set(raw_images_list)))
+print "Extra raw images: %s" % ",\n".join(
+    sorted(set(raw_images_list) - set(expected_images_list)))
+
+sd_mRNA_mat_list = map(
+    os.path.basename,
+    glob.glob("%s/*/%s/SD_mRNA*.mat" % (BASE_DIRECTORY, ANALYZED_IMAGES_DIR)))
+expected_mat_list = ['SD_mRNA_%s.mat' % x[:-4] for x in raw_images_list]
+print "Missing processed images: %s" % ",\n".join(
+    sorted(set(expected_mat_list) - set(sd_mRNA_mat_list)))
+print "Extra processed images: %s" % ",\n".join(
+    sorted(set(sd_mRNA_mat_list) - set(expected_mat_list)))

--- a/scripts/generate_companion.py
+++ b/scripts/generate_companion.py
@@ -117,4 +117,4 @@ def create_companion(name):
 
 for experiment in EXPERIMENTS:
     for timepoint in TIMEPOINTS:
-        create_companion("%s_%g" % (experiment, timepoint))
+        create_companion("%s_%gmin" % (experiment, timepoint))

--- a/scripts/generate_companion.py
+++ b/scripts/generate_companion.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+# Generate companion files
+
+
+import os
+import uuid
+import xml.etree.ElementTree as ET
+
+BASE_DIRECTORY = os.environ.get(
+    "BASE_DIRECTORY", "/uod/idr/filesets/idr0047-neuert/")
+NAME = 'Exp1_rep1_0min_im1'
+
+
+OME_ATTRIBUTES = {
+    'xmlns': 'http://www.openmicroscopy.org/Schemas/OME/2016-06',
+    'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+    'xmlns:OME': 'http://www.openmicroscopy.org/Schemas/OME/2016-06',
+    'xsi:schemaLocation': 'http://www.openmicroscopy.org/Schemas/OME/2016-06 \
+http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd',
+}
+
+IMAGES = [
+    {
+        'Image': {'ID': 'Image:0', 'Name': '3D images'},
+        'Pixels': {
+            'ID': 'Pixels:0:0',
+            'DimensionOrder': 'XYZTC',
+            'Type': 'uint16',
+            'SizeX': '2048',
+            'SizeY': '2048',
+            'SizeZ': '25',
+            'SizeC': '5',
+            'SizeT': '1',
+        },
+        'Channels': [
+            {'Color': '65535', 'ID': 'Channel:0:0',
+             'Name': 'Nuclei', 'SamplesPerPixel': '1'},
+            {'Color': '-16776961', 'ID': 'Channel:0:1',
+             'Name': 'CTT1 filter', 'SamplesPerPixel': '1'},
+            {'Color': '-16776961', 'ID': 'Channel:0:2',
+             'Name': 'CTT1 immax', 'SamplesPerPixel': '1'},
+            {'Color': '16711935', 'ID': 'Channel:0:3',
+             'Name': 'STL1 filter', 'SamplesPerPixel': '1'},
+            {'Color': '16711935', 'ID': 'Channel:0:4',
+             'Name': 'STL1 immax', 'SamplesPerPixel': '1'},
+        ],
+        'TIFFData': [
+            'M_nuclei_%s_nuclei3D.tiff',
+            'SD_mRNA_%s_CY53Dfilter.tiff',
+            'SD_mRNA_%s_CY53D3immax.tiff',
+            'SD_mRNA_%s_TMR3Dfilter.tiff',
+            'SD_mRNA_%s_TMR3D3immax.tiff'
+        ]
+    },
+    {
+        'Image': {'ID': 'Image:1', 'Name': 'Projections images'},
+        'Pixels': {
+            'ID': 'Pixels:1:0',
+            'DimensionOrder': 'XYZTC',
+            'Type': 'uint16',
+            'SizeX': '2048',
+            'SizeY': '2048',
+            'SizeZ': '1',
+            'SizeC': '7',
+            'SizeT': '1',
+        },
+        'Channels': [
+            {'Color': '-1', 'ID': 'Channel:1:0',
+             'Name': 'Cells', 'SamplesPerPixel': '1'},
+            {'Color': '-1', 'ID': 'Channel:1:1',
+             'Name': 'Brightfield processed', 'SamplesPerPixel': '1'},
+            {'Color': '65535', 'ID': 'Channel:1:2',
+             'Name': 'Nuclei', 'SamplesPerPixel': '1'},
+            {'Color': '-16776961', 'ID': 'Channel:1:3',
+             'Name': 'CTT1 immax', 'SamplesPerPixel': '1'},
+            {'Color': '-16776961', 'ID': 'Channel:1:4',
+             'Name': 'CTT1 filt', 'SamplesPerPixel': '1'},
+            {'Color': '16711935', 'ID': 'Channel:1:5',
+             'Name': 'STL1 immax', 'SamplesPerPixel': '1'},
+            {'Color': '16711935', 'ID': 'Channel:1:6',
+             'Name': 'STL1 filt', 'SamplesPerPixel': '1'},
+        ],
+        'TIFFData': [
+            'M_Lab_%s_Cells.tif',
+            'M_Lab_%s_trans_plane.tif',
+            'M_nuclei_%s_nuclei.tif',
+            'SD_mRNA_%s_CY5max.tif',
+            'SD_mRNA_%s_CY5maxF.tif',
+            'SD_mRNA_%s_TMRmax.tif',
+            'SD_mRNA_%s_TMRmaxF.tif',
+        ],
+    }
+]
+
+
+# Create an element tree representing the OME metadata
+root = ET.Element("OME", attrib=OME_ATTRIBUTES)
+for i in IMAGES:
+    image = ET.SubElement(root, "Image", attrib=i["Image"])
+    pixels = ET.SubElement(image, "Pixels", attrib=i["Pixels"])
+    for channel in i["Channels"]:
+        ET.SubElement(pixels, "Channel", attrib=channel)
+
+    tiffs = i["TIFFData"]
+    for t in range(len(tiffs)):
+        tiffdata = ET.SubElement(pixels, "TiffData", attrib={
+            "FirstC": str(t), "IFD": '0'})
+        ET.SubElement(tiffdata, "UUID", attrib={
+            "FileName": tiffs[t] % NAME}).text = str(uuid.uuid4())
+
+tree = ET.ElementTree(root)
+tree.write("%s.companion.ome" % NAME, encoding='utf-8', xml_declaration=True)

--- a/scripts/generate_companion.py
+++ b/scripts/generate_companion.py
@@ -8,8 +8,9 @@ import xml.etree.ElementTree as ET
 
 BASE_DIRECTORY = os.environ.get(
     "BASE_DIRECTORY", "/uod/idr/filesets/idr0047-neuert/")
-NAME = 'Exp1_rep1_0min_im1'
 
+EXPERIMENTS = ['Exp1_rep1', 'Exp1_rep2', 'Exp2_rep1', 'Exp2_rep2', 'Exp2_rep3']
+TIMEPOINTS = [0, 1, 2, 4, 6, 8, 10, 15, 20, 25, 30, 35, 40, 50, 55]
 
 OME_ATTRIBUTES = {
     'xmlns': 'http://www.openmicroscopy.org/Schemas/OME/2016-06',
@@ -93,20 +94,27 @@ IMAGES = [
 ]
 
 
-# Create an element tree representing the OME metadata
-root = ET.Element("OME", attrib=OME_ATTRIBUTES)
-for i in IMAGES:
-    image = ET.SubElement(root, "Image", attrib=i["Image"])
-    pixels = ET.SubElement(image, "Pixels", attrib=i["Pixels"])
-    for channel in i["Channels"]:
-        ET.SubElement(pixels, "Channel", attrib=channel)
+def create_companion(name):
+    """Create a companion OME-XML for a given experiment"""
+    root = ET.Element("OME", attrib=OME_ATTRIBUTES)
+    for i in IMAGES:
+        image = ET.SubElement(root, "Image", attrib=i["Image"])
+        pixels = ET.SubElement(image, "Pixels", attrib=i["Pixels"])
+        for channel in i["Channels"]:
+            ET.SubElement(pixels, "Channel", attrib=channel)
 
-    tiffs = i["TIFFData"]
-    for t in range(len(tiffs)):
-        tiffdata = ET.SubElement(pixels, "TiffData", attrib={
-            "FirstC": str(t), "IFD": '0'})
-        ET.SubElement(tiffdata, "UUID", attrib={
-            "FileName": tiffs[t] % NAME}).text = str(uuid.uuid4())
+        tiffs = i["TIFFData"]
+        for t in range(len(tiffs)):
+            tiffdata = ET.SubElement(pixels, "TiffData", attrib={
+                "FirstC": str(t), "IFD": '0'})
+            ET.SubElement(tiffdata, "UUID", attrib={
+                "FileName": tiffs[t] % name}).text = str(uuid.uuid4())
 
-tree = ET.ElementTree(root)
-tree.write("%s.companion.ome" % NAME, encoding='utf-8', xml_declaration=True)
+    tree = ET.ElementTree(root)
+    tree.write("%s.companion.ome" % name, encoding='utf-8',
+               xml_declaration=True)
+
+
+for experiment in EXPERIMENTS:
+    for timepoint in TIMEPOINTS:
+        create_companion("%s_%g" % (experiment, timepoint))

--- a/scripts/generate_companion.py
+++ b/scripts/generate_companion.py
@@ -11,6 +11,7 @@ BASE_DIRECTORY = os.environ.get(
 
 EXPERIMENTS = ['Exp1_rep1', 'Exp1_rep2', 'Exp2_rep1', 'Exp2_rep2', 'Exp2_rep3']
 TIMEPOINTS = [0, 1, 2, 4, 6, 8, 10, 15, 20, 25, 30, 35, 40, 50, 55]
+POSITIONS = ['im1', 'im2', 'im3', 'im4']
 
 OME_ATTRIBUTES = {
     'xmlns': 'http://www.openmicroscopy.org/Schemas/OME/2016-06',
@@ -117,4 +118,5 @@ def create_companion(name):
 
 for experiment in EXPERIMENTS:
     for timepoint in TIMEPOINTS:
-        create_companion("%s_%gmin" % (experiment, timepoint))
+        for positin in POSITIONS:
+            create_companion("%s_%gmin_%s" % (experiment, timepoint, position))

--- a/scripts/generate_companion.py
+++ b/scripts/generate_companion.py
@@ -118,5 +118,5 @@ def create_companion(name):
 
 for experiment in EXPERIMENTS:
     for timepoint in TIMEPOINTS:
-        for positin in POSITIONS:
+        for position in POSITIONS:
             create_companion("%s_%gmin_%s" % (experiment, timepoint, position))


### PR DESCRIPTION
This PR investigates the combination of all processed images generated by the submission into a multi-channel processed image.

Using pattern files as we did in https://github.com/IDR/idr0045-reichmann/pull/2 could be a possibility, however the generated data is stored as multi-page TIFF files i.e. the dimension of the stack is internally guessed as `T` while it should be `Z`.

Instead this is also testing the changes opened as https://github.com/openmicroscopy/bioformats/pull/3228 to combine plain TIFF files using a relaxed companion OME-XML.

While testing I realized absolute filepaths are currently not working for companion filesets so I switched to using relative paths. 

For an OMERO bulk import, the data layout might be important so that the correct fileset is detected. One solution would be to list each companion as a separate line. If we want to list folders and use the nice `--parallel` options, we might need a layout

```
YYYY-MM-DD-processed/
   Exp1_rep1_0min.companion.ome                                Companion file pointing to files under TIFFs
   Exp1_rep1_10min.companion.ome
   ...
      TIFFs/
         M_nuclei_Exp1_rep1_0min_im1_nuclei3D.tiff         Symlinks to the original TIFF files
         ...
```

Next step:

- [ ] agree on the representation of each processed stack (multi-image? channel numbers? channel name and colors?
- [ ] agree on the data layout (symlinks, subfolders)
- [ ] write script to generate companion files and symlinks 

/cc @manics @francesw @joshmoore 

