### PR TITLE
Fix metadata folder name to be lowercase

### DIFF
--- a/experimentA/idr0047-experimentA-filePaths.tsv
+++ b/experimentA/idr0047-experimentA-filePaths.tsv
@@ -3,8 +3,8 @@ Dataset:name:Exp1_rep2	/uod/idr/filesets/idr0047-neuert-yeastmRNA/20181016-ftp/E
 Dataset:name:Exp2_rep1	/uod/idr/filesets/idr0047-neuert-yeastmRNA/20181016-ftp/Exp2_rep1/#1_Raw_Images
 Dataset:name:Exp2_rep2	/uod/idr/filesets/idr0047-neuert-yeastmRNA/20181016-ftp/Exp2_rep2/#1_Raw_Images
 Dataset:name:Exp2_rep3	/uod/idr/filesets/idr0047-neuert-yeastmRNA/20181016-ftp/Exp2_rep3/#1_Raw_Images
-Dataset:name:Exp1_rep1 processed	/uod/idr/metadata/idr0047-neuert-yeastmRNA/companions/Exp1_rep1
-Dataset:name:Exp1_rep2 processed	/uod/idr/metadata/idr0047-neuert-yeastmRNA/companions/Exp1_rep2
-Dataset:name:Exp2_rep1 processed	/uod/idr/metadata/idr0047-neuert-yeastmRNA/companions/Exp2_rep1
-Dataset:name:Exp2_rep2 processed	/uod/idr/metadata/idr0047-neuert-yeastmRNA/companions/Exp2_rep2
-Dataset:name:Exp2_rep3 processed	/uod/idr/metadata/idr0047-neuert-yeastmRNA/companions/Exp2_rep3
+Dataset:name:Exp1_rep1 processed	/uod/idr/metadata/idr0047-neuert-yeastmrna/companions/Exp1_rep1
+Dataset:name:Exp1_rep2 processed	/uod/idr/metadata/idr0047-neuert-yeastmrna/companions/Exp1_rep2
+Dataset:name:Exp2_rep1 processed	/uod/idr/metadata/idr0047-neuert-yeastmrna/companions/Exp2_rep1
+Dataset:name:Exp2_rep2 processed	/uod/idr/metadata/idr0047-neuert-yeastmrna/companions/Exp2_rep2
+Dataset:name:Exp2_rep3 processed	/uod/idr/metadata/idr0047-neuert-yeastmrna/companions/Exp2_rep3


### PR DESCRIPTION
Together with https://github.com/IDR/idr-metadata/pull/339, this should allow to reimport the processed images from the correct folder name 

/ccc @dominikl @manics 